### PR TITLE
Save defaultBang setting to localStorage

### DIFF
--- a/src/components/SettingsModal.ts
+++ b/src/components/SettingsModal.ts
@@ -156,6 +156,13 @@ export class SettingsModal {
     }, ['Save Settings']);
     saveButton.addEventListener('click', () => {
       saveSettings(this.settings);
+      // Save default bang to local storage if set
+      if (this.settings.defaultBang) {
+        localStorage.setItem('defaultBang', this.settings.defaultBang);
+      } else {
+        localStorage.removeItem('defaultBang'); // Remove if not set to fall back on default
+      }
+
       this.onSettingsChange(this.settings);
       this.hide();
     });


### PR DESCRIPTION
**Changes:**
- Checks that settings.defaultBang is not blank and then writes it to local storage, clears if it is empty.

This bugged me slightly, so I fixed it. :slightly_smiling_face: 