### PR TITLE
Add back minecraft.wiki

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -35065,6 +35065,15 @@ export const bangs = [{
   },
 {
     c: "Entertainment",
+    d: "minecraft.wiki",
+    r: 0,
+    s: "Minecraft Wiki",
+    sc: "Games (Minecraft)",
+    t: "minecraft",
+    u: "https://minecraft.wiki/w/Special:Search?search={{{s}}}",
+  },
+{
+    c: "Entertainment",
     d: "minecraft-seeds.net",
     r: 0,
     s: "Minecraft Seeds",


### PR DESCRIPTION
Hello! (Again) 

Revealing that I'm a Minecraft player here, but when you purged all the bangs, you removed one I used.

Blam you can now use the !minecraft bang to search on minecraft.wiki